### PR TITLE
Python3

### DIFF
--- a/Day-1/Notebook/Converting Notebooks With nbconvert.ipynb
+++ b/Day-1/Notebook/Converting Notebooks With nbconvert.ipynb
@@ -146,7 +146,7 @@
    "source": [
     "pyfile = !ipython nbconvert --to python 'Index.ipynb' --stdout\n",
     "for l in pyfile[20:40]:\n",
-    "    print l"
+    "    print(l)"
    ]
   },
   {
@@ -191,8 +191,8 @@
     "pyfile = !ipython nbconvert --to python 'Index.ipynb' --stdout --template=simplepython.tpl\n",
     "\n",
     "for l in pyfile[4:40]:\n",
-    "    print l\n",
-    "print '...'"
+    "    print(l)\n",
+    "print('...')"
    ]
   },
   {

--- a/Day-1/Notebook/JavaScript Notebook Extensions.ipynb
+++ b/Day-1/Notebook/JavaScript Notebook Extensions.ipynb
@@ -174,7 +174,7 @@
     "#  my custom js\n",
     "with open(custom_js_path) as f:\n",
     "    for l in f: \n",
-    "        print l,"
+    "        print(l)"
    ]
   },
   {

--- a/Day-1/Notebook/Running Code.ipynb
+++ b/Day-1/Notebook/Running Code.ipynb
@@ -47,7 +47,6 @@
    },
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
     "print(a)"
    ]
   },
@@ -174,7 +173,6 @@
    },
    "outputs": [],
    "source": [
-    "from __future__ import print_function\n",
     "print(\"hi, stdout\")"
    ]
   },
@@ -186,6 +184,7 @@
    },
    "outputs": [],
    "source": [
+    "import sys\n",
     "print('hi, stderr', file=sys.stderr)"
    ]
   },


### PR DESCRIPTION
A few places where python2 syntax (usually prints) are used instead of python3. I think for this course it's been fixed that python3 is required?
